### PR TITLE
Fix parsing of *args and **kwargs

### DIFF
--- a/src/pytkdocs/parsers/docstrings.py
+++ b/src/pytkdocs/parsers/docstrings.py
@@ -303,7 +303,7 @@ class DocstringParser:
             kind = None
 
             try:
-                signature_param = self.signature.parameters[name]  # type: ignore
+                signature_param = self.signature.parameters[name.lstrip("*")]  # type: ignore
             except (AttributeError, KeyError):
                 self.parsing_errors.append(f"{self.path}: No type annotation for parameter '{name}'")
             else:

--- a/tests/test_parsers/test_docstrings.py
+++ b/tests/test_parsers/test_docstrings.py
@@ -344,3 +344,21 @@ class TestDocstringParser:
         sections, errors = parse(inspect.getdoc(f), inspect.signature(f))
         assert len(sections) == 2
         assert not errors
+
+    def test_parse_args_kwargs(self):
+        def f(a, *args, **kwargs):
+            """
+            Arguments:
+                a: a parameter.
+                *args: args parameters.
+                **kwargs: kwargs parameters.
+            """
+            return 1
+
+        sections, errors = parse(inspect.getdoc(f), inspect.signature(f))
+        assert len(sections) == 1
+        expected_parameters = {"a": "a parameter.", "*args": "args parameters.", "**kwargs": "kwargs parameters."}
+        for param in sections[0].value:
+            assert param.name in expected_parameters
+            assert expected_parameters[param.name] == param.description
+        assert not errors


### PR DESCRIPTION
The inspect library stores the `*args` and `**kwargs` parameters under the keys `args` and `kwargs` respectively. This behavior caused a key error when looking for the parameters using the  `*args` and `**kwargs` keys.

Issue: https://github.com/pawamoy/pytkdocs/issues/20