### PR TITLE
Fix unable to find root namespace

### DIFF
--- a/src/pytkdocs/objects.py
+++ b/src/pytkdocs/objects.py
@@ -182,10 +182,10 @@ class Object(metaclass=ABCMeta):
                 importlib.import_module(namespace)
                 top_package = sys.modules[namespace]
             except (KeyError, ImportError):
-                """
-                Triggered if we can't import the package via importlib
-                Or if package isn't findable by it's canonical name even after importing
-                """
+                # ImportError: Triggered if the package is not importable
+                # KeyError: Triggered if the imported package isn't referenced under the same fully qualified name
+                # Namespace packages are importable, so this should work for them
+
                 return ""
 
             try:

--- a/src/pytkdocs/objects.py
+++ b/src/pytkdocs/objects.py
@@ -176,7 +176,7 @@ class Object(metaclass=ABCMeta):
 
         parts = self.path.split(".")
         namespaces = [".".join(parts[:l]) for l in range(1, len(parts) + 1)]
-        # Itterate through all sub namespaces including the last incase its a module
+        # Iterate through all sub namespaces including the last in case it is a module
         for namespace in namespaces:
             try:
                 importlib.import_module(namespace)

--- a/src/pytkdocs/objects.py
+++ b/src/pytkdocs/objects.py
@@ -175,17 +175,17 @@ class Object(metaclass=ABCMeta):
         """
 
         parts = self.path.split(".")
-        namespaces = [".".join(parts[:l]) for l in range(1, len(parts))]
-
+        namespaces = [".".join(parts[:l]) for l in range(1, len(parts) + 1)]
+        # Itterate through all sub namespaces including the last incase its a module
         for namespace in namespaces:
             try:
                 importlib.import_module(namespace)
                 top_package = sys.modules[namespace]
-            except (KeyError, ImportError):
-                # ImportError: Triggered if the package is not importable
+            except (ImportError, ModuleNotFoundError, KeyError):
+                # ImportError: Triggered if the namespace is not importable
+                # ModuleNotFoundError: Triggered if the namespace is not a module
                 # KeyError: Triggered if the imported package isn't referenced under the same fully qualified name
                 # Namespace packages are importable, so this should work for them
-
                 return ""
 
             try:

--- a/src/pytkdocs/objects.py
+++ b/src/pytkdocs/objects.py
@@ -194,6 +194,8 @@ class Object(metaclass=ABCMeta):
             except TypeError:
                 pass
 
+        return ""
+
     @property
     def name_to_check(self) -> str:
         """The attribute to check against name properties regular expressions (private, class-private, special)."""

--- a/src/pytkdocs/objects.py
+++ b/src/pytkdocs/objects.py
@@ -174,8 +174,8 @@ class Object(metaclass=ABCMeta):
         If the relative file path cannot be determined, the value returned is `""` (empty string).
         """
 
-        subspace_count = len(self.path.split("."))
-        namespaces = [".".join(self.path.split(".", maxsplit=maxsplit)[:-1]) for maxsplit in range(1, subspace_count)]
+        parts = self.path.split(".")
+        namespaces = [".".join(parts[:l]) for l in range(1, len(parts))]
 
         for namespace in namespaces:
             try:

--- a/src/pytkdocs/objects.py
+++ b/src/pytkdocs/objects.py
@@ -179,20 +179,24 @@ class Object(metaclass=ABCMeta):
 
         for namespace in namespaces:
             try:
+                importlib.import_module(namespace)
                 top_package = sys.modules[namespace]
-            except KeyError:
-                try:
-                    importlib.import_module(namespace)
-                except ImportError:
-                    return ""
-                top_package = sys.modules[namespace]
+            except (KeyError, ImportError):
+                """
+                Triggered if we can't import the package via importlib
+                Or if package isn't findable by it's canonical name even after importing
+                """
+                return ""
+
             try:
                 top_package_path = Path(inspect.getabsfile(top_package)).parent
                 return str(Path(self.file_path).relative_to(top_package_path.parent))
-            except ValueError:
-                return ""
             except TypeError:
+                # Triggered if getabsfile() can't be found in the case of a Namespace package
                 pass
+            except ValueError:
+                # Triggered if Path().relative_to can't find an appropriate path
+                return ""
 
         return ""
 

--- a/tests/fixtures/test_namespace/subspace/__init__.py
+++ b/tests/fixtures/test_namespace/subspace/__init__.py
@@ -1,0 +1,1 @@
+"The subspace package docstring."

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,10 +1,13 @@
 """Tests for [the `loader` module][pytkdocs.loader]."""
 
 import sys
+from pathlib import Path
 
 import pytest
 
 from pytkdocs.loader import Loader, get_object_tree
+
+from . import FIXTURES_DIR
 
 
 def test_import_no_path():
@@ -80,6 +83,15 @@ def test_loading_package():
     loader = Loader()
     obj = loader.get_object_documentation("tests.fixtures.the_package")
     assert obj.docstring == "The package docstring."
+
+
+def test_loading_namespace_package():
+    loader = Loader()
+    old_paths = list(sys.path)
+    sys.path.append(str(Path(FIXTURES_DIR).resolve()))
+    obj = loader.get_object_documentation("test_namespace.subspace")
+    assert obj.docstring == "The subspace package docstring."
+    sys.path = old_paths
 
 
 def test_loading_module():

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -91,6 +91,7 @@ def test_loading_namespace_package():
     sys.path.append(str(Path(FIXTURES_DIR).resolve()))
     obj = loader.get_object_documentation("test_namespace.subspace")
     assert obj.docstring == "The subspace package docstring."
+    assert obj.relative_file_path == "subspace/__init__.py"
     sys.path = old_paths
 
 


### PR DESCRIPTION
This fixes an issue finding the relative path when the root package is a namespace package. This is likely to break if the namespace package is nested in the module like `my_package.plugins` and you want to document something that lives in that plugins namespace. 