### PR TITLE
add initial marshmallow support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ git-changelog = "^0.4.0"
 ipython = "^7.2"
 isort = { version = "^4.3", extras = ["pyproject"] }
 jinja2-cli = "^0.7.0"
+marshmallow = "^3.5.2"
 mkdocs = "^1.1"
 mkdocs-material = ">=4.5, <6.0"
 mkdocstrings = "^0.12.0"

--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -353,23 +353,6 @@ class Loader:
 
         select_members = select_members or set()
 
-        # Blacklist inherited marshmallow properties
-        blacklist = []
-        if issubclass(class_, Schema):
-            blacklist += [
-                "__class__",
-                "Meta",
-                "OPTIONS_CLASS",
-                "dump",
-                "dumps",
-                "get_attribute",
-                "handle_error",
-                "load",
-                "loads",
-                "on_bind_field",
-                "validate",
-            ]
-
         # Build the list of members
         members = {}
         inherited = set()
@@ -378,7 +361,7 @@ class Loader:
         for member_name, member in all_members.items():
             if not (member is type or member is object) and self.select(member_name, select_members):
                 if member_name not in direct_members:
-                    if self.select_inherited_members and member_name not in blacklist:
+                    if self.select_inherited_members:
                         members[member_name] = member
                         inherited.add(member_name)
                 else:
@@ -421,7 +404,7 @@ class Loader:
                     root_object.add_child(self.get_pydantic_field_documentation(child_node))
 
         # Check if this is a marshmallow class
-        if "_declared_fields" in direct_members or (
+        elif "_declared_fields" in direct_members or (
             self.select_inherited_members and "_declared_fields" in all_members
         ):
             root_object.properties = ["marshmallow-model"]

--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -15,8 +15,6 @@ from itertools import chain
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Union
 
-from marshmallow import Schema
-
 from pytkdocs.objects import Attribute, Class, Function, Method, Module, Object, Source
 from pytkdocs.parsers.attributes import get_class_attributes, get_instance_attributes, get_module_attributes, merge
 from pytkdocs.parsers.docstrings import PARSERS

--- a/tests/fixtures/marshmallow.py
+++ b/tests/fixtures/marshmallow.py
@@ -1,0 +1,8 @@
+from marshmallow import Schema, fields
+
+
+class Person(Schema):
+    """Simple Marshmallow Model for a person's information"""
+
+    name: fields.Str = fields.Str(description="The person's name", required=True)
+    age: fields.Int = fields.Int(description="The person's age which must be at minimum 18")

--- a/tests/fixtures/parsing/attributes.py
+++ b/tests/fixtures/parsing/attributes.py
@@ -256,4 +256,5 @@ class MarshmallowSchema(Schema):
     model_field: fields.Str = fields.Str()
     """A model field."""
 
+
 OK, WARNING, CRITICAL, UNKNOWN = 0, 0, 0, 0

--- a/tests/fixtures/parsing/attributes.py
+++ b/tests/fixtures/parsing/attributes.py
@@ -11,8 +11,8 @@ Attributes:
 from datetime import datetime
 from typing import Optional, Tuple
 
-from pydantic import BaseModel
 from marshmallow import Schema, fields
+from pydantic import BaseModel
 
 NO_DOC_NO_TYPE = 0
 

--- a/tests/fixtures/parsing/attributes.py
+++ b/tests/fixtures/parsing/attributes.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Optional, Tuple
 
 from pydantic import BaseModel
+from marshmallow import Schema, fields
 
 NO_DOC_NO_TYPE = 0
 
@@ -247,5 +248,12 @@ class Model(BaseModel):
     model_field: Optional[datetime] = None
     """A model field."""
 
+
+class MarshmallowSchema(Schema):
+    in_marshmallow_model: int
+    """In Marshmallow model."""
+
+    model_field: fields.Str = fields.Str()
+    """A model field."""
 
 OK, WARNING, CRITICAL, UNKNOWN = 0, 0, 0, 0

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -4,6 +4,8 @@ import os
 import sys
 from pathlib import Path
 
+from marshmallow import fields
+
 import pytest
 from tests import FIXTURES_DIR
 
@@ -159,7 +161,6 @@ def test_loading_pydantic_model():
 
 def test_loading_marshmallow_model():
     """Handle Marshmallow models."""
-    from marshmallow import fields
     loader = Loader()
     obj = loader.get_object_documentation("tests.fixtures.marshmallow.Person")
     assert obj.docstring == "Simple Marshmallow Model for a person's information"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -4,9 +4,8 @@ import os
 import sys
 from pathlib import Path
 
-from marshmallow import fields
-
 import pytest
+from marshmallow import fields
 from tests import FIXTURES_DIR
 
 from pytkdocs.loader import Loader, get_object_tree

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -157,6 +157,24 @@ def test_loading_pydantic_model():
     assert "pydantic-field" in age_attr.properties
 
 
+def test_loading_marshmallow_model():
+    """Handle Marshmallow models."""
+    from marshmallow import fields
+    loader = Loader()
+    obj = loader.get_object_documentation("tests.fixtures.marshmallow.Person")
+    assert obj.docstring == "Simple Marshmallow Model for a person's information"
+    assert "marshmallow-model" in obj.properties
+    name_attr = next(attr for attr in obj.attributes if attr.name == "name")
+    assert name_attr.type == fields.Str
+    assert name_attr.docstring == "The person's name"
+    assert "marshmallow-field" in name_attr.properties
+    assert "required" in name_attr.properties
+    age_attr = next(attr for attr in obj.attributes if attr.name == "age")
+    assert age_attr.type == fields.Int
+    assert age_attr.docstring == "The person's age which must be at minimum 18"
+    assert "marshmallow-field" in age_attr.properties
+
+
 def test_loading_nested_class():
     """Select nested class."""
     loader = Loader()

--- a/tests/test_parsers/test_attributes.py
+++ b/tests/test_parsers/test_attributes.py
@@ -129,3 +129,19 @@ class TestPydanticFields:
 
         assert "model_field" in self.attributes
         assert self.attributes["model_field"]["docstring"] == "A model field."
+
+
+class TestMarshmallowFields:
+    """Test the parser for module attributes."""
+
+    def setup(self):
+        """Setup reusable attributes."""
+        self.attributes = get_class_attributes(attr_module.MarshmallowSchema)
+
+    def test_pick_up_attribute_in_pydantic_model(self):
+        """Pick up attribute in Marshmallow model."""
+        assert "in_marshmallow_model" in self.attributes
+        assert self.attributes["in_marshmallow_model"]["docstring"] == "In Marshmallow model."
+
+        assert "model_field" in self.attributes
+        assert self.attributes["model_field"]["docstring"] == "A model field."


### PR DESCRIPTION
Basic support for marshmallow schemas https://marshmallow.readthedocs.io/en/stable/

It would be nice if we could override the default renderer for these types of classes to show a table instead of the header style renderer?