### PR TITLE
fix #54: Use inspect.cleandoc for stripping docstring whitespace

### DIFF
--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -9,7 +9,6 @@ import importlib
 import inspect
 import pkgutil
 import re
-import textwrap
 from functools import lru_cache
 from itertools import chain
 from pathlib import Path
@@ -333,7 +332,7 @@ class Loader:
             The documented class object.
         """
         class_ = node.obj
-        docstring = textwrap.dedent(class_.__doc__ or "")
+        docstring = inspect.cleandoc(class_.__doc__ or "")
         root_object = Class(name=node.name, path=node.dotted_path, file_path=node.file_path, docstring=docstring)
 
         # Even if we don't select members, we want to correctly parse the docstring

--- a/tests/fixtures/first_line_class_docstring.py
+++ b/tests/fixtures/first_line_class_docstring.py
@@ -1,0 +1,7 @@
+class TheClass:
+    """The first line of the docstring.
+
+    A bit more of the docstring.
+    """
+
+    pass

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -124,6 +124,13 @@ def test_loading_class():
     assert obj.docstring == "The class docstring."
 
 
+def test_loading_class_with_multiline_docstring_starting_on_first_line():
+    """Handle classes with multiline docstrings where the first line is next to the triple-quotes."""
+    loader = Loader()
+    obj = loader.get_object_documentation("tests.fixtures.first_line_class_docstring.TheClass")
+    assert obj.docstring == """The first line of the docstring.\n\nA bit more of the docstring."""
+
+
 def test_loading_dataclass():
     """Handle dataclasses."""
     loader = Loader()


### PR DESCRIPTION
Let me know if there's a better place to put the test (or if you'd rather leave out the test)