### PR TITLE
fix: Prevent crash in case of empty dataclasses

### DIFF
--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -405,18 +405,16 @@ class Loader:
             self.select_inherited_members and "__fields__" in all_members
         ):
             root_object.properties = ["dataclass"]
-            # In dataclasses: "A field is defined as class variable that has a type annotation"
-            # so we can get all fields simply by iterating through the __annotations__
-            if "__annotations__" in all_members:
-                for field_name, annotation in all_members["__annotations__"].items():
-                    if self.select(field_name, select_members) and (  # type: ignore
-                        self.select_inherited_members
-                        # Same comment as for Pydantic models
-                        or field_name
-                        not in chain(*(getattr(cls, "__dataclass_fields__", {}).keys() for cls in class_.__mro__[1:-1]))
-                    ):
-                        child_node = ObjectNode(obj=annotation, name=field_name, parent=node)
-                        root_object.add_child(self.get_annotated_dataclass_field(child_node))
+
+            for field in all_members["__dataclass_fields__"].values():
+                if self.select(field.name, select_members) and (  # type: ignore
+                    self.select_inherited_members
+                    # Same comment as for Pydantic models
+                    or field.name
+                    not in chain(*(getattr(cls, "__dataclass_fields__", {}).keys() for cls in class_.__mro__[1:-1]))
+                ):
+                    child_node = ObjectNode(obj=field.type, name=field.name, parent=node)
+                    root_object.add_child(self.get_annotated_dataclass_field(child_node))
 
         return root_object
 

--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -405,15 +405,18 @@ class Loader:
             self.select_inherited_members and "__fields__" in all_members
         ):
             root_object.properties = ["dataclass"]
-            for field_name, annotation in all_members["__annotations__"].items():
-                if self.select(field_name, select_members) and (  # type: ignore
-                    self.select_inherited_members
-                    # Same comment as for Pydantic models
-                    or field_name
-                    not in chain(*(getattr(cls, "__dataclass_fields__", {}).keys() for cls in class_.__mro__[1:-1]))
-                ):
-                    child_node = ObjectNode(obj=annotation, name=field_name, parent=node)
-                    root_object.add_child(self.get_annotated_dataclass_field(child_node))
+            # In dataclasses: "A field is defined as class variable that has a type annotation"
+            # so we can get all fields simply by iterating through the __annotations__
+            if "__annotations__" in all_members:
+                for field_name, annotation in all_members["__annotations__"].items():
+                    if self.select(field_name, select_members) and (  # type: ignore
+                        self.select_inherited_members
+                        # Same comment as for Pydantic models
+                        or field_name
+                        not in chain(*(getattr(cls, "__dataclass_fields__", {}).keys() for cls in class_.__mro__[1:-1]))
+                    ):
+                        child_node = ObjectNode(obj=annotation, name=field_name, parent=node)
+                        root_object.add_child(self.get_annotated_dataclass_field(child_node))
 
         return root_object
 

--- a/tests/fixtures/dataclass.py
+++ b/tests/fixtures/dataclass.py
@@ -13,4 +13,5 @@ class Person:
 @dataclass
 class Empty:
     """A dataclass without any fields"""
+
     pass

--- a/tests/fixtures/dataclass.py
+++ b/tests/fixtures/dataclass.py
@@ -8,3 +8,9 @@ class Person:
     name: str
     age: int
     """Field description."""
+
+
+@dataclass
+class Empty:
+    """A dataclass without any fields"""
+    pass

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -148,6 +148,15 @@ def test_loading_dataclass():
     assert "dataclass" not in not_dataclass.properties
 
 
+def test_loading_empty_dataclass():
+    """Handle empty dataclasses."""
+    loader = Loader()
+    obj = loader.get_object_documentation("tests.fixtures.dataclass.Empty")
+    assert obj.docstring == "A dataclass without any fields"
+    assert len(obj.attributes) == 0
+    assert "dataclass" in obj.properties
+
+
 def test_loading_pydantic_model():
     """Handle Pydantic models."""
     loader = Loader()


### PR DESCRIPTION
Ran into this when applying mkdocstrings to a real life project. I won't pretend that there was a legitimate reason to use an empty dataclass in my code, but thought it was worth preventing the crash 🙈