### PR TITLE
chore: Update CI workflow into a better state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Python 3.6
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.6
 
@@ -37,19 +37,19 @@ jobs:
       run: |
         pip install poetry invoke safety
         poetry config virtualenvs.in-project true
-        make setup
+        bash ./scripts/setup.sh
 
     - name: Check if the documentation builds correctly
-      run: make check-docs
+      run: poetry run invoke check-docs
 
     - name: Check the code quality
-      run: make check-code-quality
+      run: poetry run invoke check-code-quality
 
     - name: Check if the code is correctly typed
-      run: make check-types
+      run: poetry run invoke check-types
 
     - name: Check for vulnerabilities in dependencies
-      run: make check-dependencies
+      run: poetry run invoke check-dependencies
 
   tests:
 
@@ -66,7 +66,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -85,7 +85,12 @@ jobs:
       run: |
         pip install poetry invoke
         poetry config virtualenvs.in-project true
-        make setup
+        bash ./scripts/setup.sh
 
-    - name: Run the test suite
-      run: make test
+    - name: Run the test suite (Not Windows)
+      run: poetry run invoke test
+      if: ${{ runner.os != 'Windows' }}
+
+    - name: Run the test suite (Windows)
+      run: poetry run pytest -c config/pytest.ini -n auto src scripts tests tasks.py
+      if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
I spent some time to get the CI pipeline into a better state. 

There is one issue that I can't explain. I had gotten [everything working](https://github.com/plannigan/pytkdocs/actions/runs/300546337). However, after I squashed all the debugging commits into a single clean commit, [installing the dependencies on Windows](https://github.com/plannigan/pytkdocs/runs/1238411387?check_suite_focus=true) always hangs instead of completing. If this persists, maybe running CI on Windows can be disabled for now.

Changes:
* Use `setup.sh` directly instead of `make` so it will only setup project for the python version of CI step. On Windows, [poetry wasn't finding the correct python executable](https://github.com/plannigan/pytkdocs/runs/1238115874?check_suite_focus=true#step:5:86). However, `actions/setup-python` ensures that `python` will point to the correct version.
* Directly invoke commands with poetry. Since the pipeline is using the matrix to test on multiple python versions, `make` would try to use the other versions that weren't available.
* Update version of actions/setup-python. Might not be needed, but was something I changed why debugging. (There is also a newer version of `actions/cache` that could be used.)
* Run pytest directly on Window because [failprint could not find executable](https://github.com/plannigan/pytkdocs/runs/1238167239?check_suite_focus=true#step:6:26). Might be related to pawamoy/failprint#6.

Other notes:
* The quality step displays a success even though `flakehell` displays multiple errors. Once those are addressed, the task can be changed to not silence errors.
* `failprint` works very well for local development, especially when testing against multiple python versions. However, using as part of the CI pipeline made a few things harder to debug and see what was happening. Maybe this could be removed from CI runs in a future change.