### PR TITLE
Explicitly test with no arguments

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,7 @@ def test_read_whole_stdin(monkeypatch):
         ),
     )
 
-    cli.main()
+    cli.main([])
 
 
 def test_read_stdin_line_by_line(monkeypatch):


### PR DESCRIPTION
In the normal flow, there is no difference. However, running `pytest` directly with arguments would cause those arguments to be used by the test case.