### PR TITLE
fix: Avoid recursion if a class has a reference to itself.

### DIFF
--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -456,6 +456,8 @@ class Loader:
         direct_members = class_.__dict__
         all_members = dict(inspect.getmembers(class_))
         for member_name, member in all_members.items():
+            if member is class_:
+                continue
             if not (member is type or member is object) and self.select(member_name, select_members):
                 if member_name not in direct_members:
                     if self.select_inherited_members:


### PR DESCRIPTION
I was attempting to use `mkdocstrings` with some Python library I maintain, only to find it failed because one of the classes referred to itself in one of its members. I'm not sure if this fix is ideal (since it omits the member entirely rather than including it but making it clear that there is a self-reference involved; and it doesn't deal with with non-local recursion).

What are your thoughts?