### PR TITLE
fix: Allow newer version of dataclasses backport

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-dataclasses = {version = "^0.7", python = "3.6"}
+dataclasses = {version = ">=0.7 <0.9", python = "3.6"}
 typing-extensions = {version = "^3.7.4.3", python = "3.6 || 3.7"}
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
A new version of `dataclasses` was [released last month](https://pypi.org/project/dataclasses/#history).

This should resolve the issue that caused pawamoy/mkdocstrings#198 to fail. I looked at `poetry`'s extra verbose install output:
```
...
   1: fact: black (20.8b1) depends on dataclasses (>=0.6)
   1: selecting black (20.8b1)
   1: derived: dataclasses (>=0.6)
...
   1: selecting dataclasses (0.8)
...
   1: fact: pytkdocs (0.10.0) depends on dataclasses (>=0.7,<0.8)
   1: fact: pytkdocs (0.10.0) depends on typing-extensions (>=3.7.4.3,<4.0.0.0)
   1: derived: not pytkdocs (0.10.0)
   1: selecting pytkdocs (0.9.0)
...
```
`dataclasses` doesn't show up anywhere else in the file. So based on that, it would seem like `poetry` should be able to backtrack and select an older version of `dataclasses`, but it doesn't. Maybe there are other packages that use `dataclasses`, but that isn't being displayed in the log. It is also odd that I was doing my testing in a Python 3.8 environment, so `dataclasses` shouldn't be getting installed at all.

In either case, this change makes it so that the latest version of `dataclasses` is allowed to be used.